### PR TITLE
Add sharing option and fix re-rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
         <link rel="icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Bellingcat Open Source Challenge</title>
+        <meta property="og:title" content="Bellingcat Open Source Challenge" />
+        <meta
+            property="og:description"
+            content="Test your open source research skills."
+        />
     </head>
 
     <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "crypto-js": "^4.2.0",
                 "roboto-fontface": "*",
                 "vue": "^3.4.31",
-                "vue3-social-sharing": "^1.3.1",
+                "vue3-social-sharing": "^1.4.0",
                 "vuetify": "^3.6.11",
                 "yaml-front-matter": "^4.1.1"
             },
@@ -1825,9 +1825,9 @@
             }
         },
         "node_modules/vue3-social-sharing": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/vue3-social-sharing/-/vue3-social-sharing-1.3.1.tgz",
-            "integrity": "sha512-1WxhmLzy51HKGDoZ474K+r+C16sJMdhUQ05DU7aEQdZE8CZQFFzJM3DixvAnVHzBwWFFkktj2HFxJGCT7XjnIg==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/vue3-social-sharing/-/vue3-social-sharing-1.4.1.tgz",
+            "integrity": "sha512-VzH3iSxvszb4628k4ZrGgQOAAXMLX0B+QJJvChdZqaiXNsW5LGoBSr2Xd2sXcGfiSwmVgcerfa+/HLM++Mozng==",
             "license": "MIT",
             "dependencies": {
                 "vue": "^3.3.11"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
             "name": "advent",
             "version": "0.0.0",
             "dependencies": {
+                "@fortawesome/fontawesome-free": "^6.7.2",
                 "@mdi/font": "7.4.47",
                 "@vueuse/core": "^11.2.0",
                 "crypto-js": "^4.2.0",
                 "roboto-fontface": "*",
                 "vue": "^3.4.31",
+                "vue3-social-sharing": "^1.3.1",
                 "vuetify": "^3.6.11",
                 "yaml-front-matter": "^4.1.1"
             },
@@ -421,6 +423,15 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-free": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+            "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+            "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -1811,6 +1822,18 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vue3-social-sharing": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/vue3-social-sharing/-/vue3-social-sharing-1.3.1.tgz",
+            "integrity": "sha512-1WxhmLzy51HKGDoZ474K+r+C16sJMdhUQ05DU7aEQdZE8CZQFFzJM3DixvAnVHzBwWFFkktj2HFxJGCT7XjnIg==",
+            "license": "MIT",
+            "dependencies": {
+                "vue": "^3.3.11"
+            },
+            "peerDependencies": {
+                "vue": "^3.3.11"
             }
         },
         "node_modules/vuetify": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
         "format": "prettier --write ."
     },
     "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@mdi/font": "7.4.47",
         "@vueuse/core": "^11.2.0",
         "crypto-js": "^4.2.0",
         "roboto-fontface": "*",
         "vue": "^3.4.31",
+        "vue3-social-sharing": "^1.3.1",
         "vuetify": "^3.6.11",
         "yaml-front-matter": "^4.1.1"
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "crypto-js": "^4.2.0",
         "roboto-fontface": "*",
         "vue": "^3.4.31",
-        "vue3-social-sharing": "^1.3.1",
+        "vue3-social-sharing": "^1.4.1",
         "vuetify": "^3.6.11",
         "yaml-front-matter": "^4.1.1"
     },

--- a/src/components/AsyncApp.vue
+++ b/src/components/AsyncApp.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-row :key="renderKey" class="mx-1 my-2">
+    <v-row class="mx-1 my-2">
         <template v-for="(challenge, index) in challengesList" :key="index">
             <ChallengeRow :challenge="challenge" />
         </template>
@@ -27,7 +27,6 @@ const challengesList = computed(() =>
         return bDate - aDate;
     }),
 );
-const renderKey = ref(0);
 onMounted(() => run_on_mount_and_update());
 onUpdated(() => run_on_mount_and_update());
 
@@ -96,14 +95,5 @@ function run_on_mount_and_update() {
             }
         }
     }
-    // watch the challenges object for deep changes
-    watch(
-        () => challenges.value,
-        (newChallenges) => {
-            // rerender the component by incrementing the renderKey
-            renderKey.value += 1;
-        },
-        { deep: true },
-    );
 }
 </script>

--- a/src/components/PuzzlePage.vue
+++ b/src/components/PuzzlePage.vue
@@ -106,6 +106,9 @@
                             </v-btn>
                         </template>
                     </v-text-field>
+                    <template v-if="metadata.solved">
+                        <puzzle-share :puzzle="puzzle"></puzzle-share>
+                    </template>
                 </v-container>
             </v-col>
         </v-row>

--- a/src/components/PuzzlePage.vue
+++ b/src/components/PuzzlePage.vue
@@ -107,7 +107,9 @@
                         </template>
                     </v-text-field>
                     <template v-if="metadata.solved">
-                        <puzzle-share :puzzle="puzzle"></puzzle-share>
+                        <puzzle-share
+                            :puzzle-title="puzzle.title"
+                        ></puzzle-share>
                     </template>
                 </v-container>
             </v-col>

--- a/src/components/PuzzleShare.vue
+++ b/src/components/PuzzleShare.vue
@@ -1,9 +1,6 @@
 <template>
     <div class="text-center">
-        <h2>Congratulations, you have solved this challenge!</h2>
-        <p class="my-2">
-            Share your success and motivate others to give it a try!
-        </p>
+        <h2>Congratulations! You solved this challenge! 🎉</h2>
         <div>
             <ShareNetwork
                 v-for="network in socialNetworks"
@@ -11,8 +8,7 @@
                 :network="network.name"
                 v-slot="{ share }"
                 url="https://challenge.bellingcat.com/"
-                :title="`I've just solved the '${puzzleTitle}' challenge on Bellingcat 🏆 Try it yourself!`"
-                twitter-user="bellingcat"
+                :title="`I just solved Bellingcat's '${puzzleTitle}' challenge 🏆 Try it yourself!`"
             >
                 <v-btn
                     variant="flat"
@@ -27,6 +23,9 @@
                 </v-btn>
             </ShareNetwork>
         </div>
+        <p class="my-2">
+            Share your success and encourage others to give it a try.
+        </p>
     </div>
 </template>
 

--- a/src/components/PuzzleShare.vue
+++ b/src/components/PuzzleShare.vue
@@ -2,15 +2,17 @@
     <div class="text-center">
         <h2>Congratulations, you have solved this challenge!</h2>
         <p class="my-2">
-            Share your success and motivate your friends to give it a try!
+            Share your success and motivate others to give it a try!
         </p>
         <div>
             <ShareNetwork
                 v-for="network in socialNetworks"
                 :key="network.name"
                 :network="network.name"
-                url="https://challenge.bellingcat.com/"
                 v-slot="{ share }"
+                url="https://challenge.bellingcat.com/"
+                :title="`I've just solved the '${puzzleTitle}' challenge on Bellingcat 🏆 Try it yourself!`"
+                twitter-user="bellingcat"
             >
                 <v-btn
                     variant="flat"
@@ -34,6 +36,6 @@ import { ShareNetwork } from "vue3-social-sharing";
 import socialNetworks from "@/data/social";
 
 defineProps({
-    puzzle: Object,
+    puzzleTitle: String,
 });
 </script>

--- a/src/components/PuzzleShare.vue
+++ b/src/components/PuzzleShare.vue
@@ -1,0 +1,39 @@
+<template>
+    <div class="text-center">
+        <h2>Congratulations, you have solved this challenge!</h2>
+        <p class="my-2">
+            Share your success and motivate your friends to give it a try!
+        </p>
+        <div>
+            <ShareNetwork
+                v-for="network in socialNetworks"
+                :key="network.name"
+                :network="network.name"
+                url="https://challenge.bellingcat.com/"
+                v-slot="{ share }"
+            >
+                <v-btn
+                    variant="flat"
+                    color="primary"
+                    @click="share"
+                    class="text-capitalize mt-2 mx-2 px-3"
+                >
+                    <v-icon :size="16" class="mr-1">
+                        {{ network.icon }}
+                    </v-icon>
+                    {{ network.label }}
+                </v-btn>
+            </ShareNetwork>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { defineProps } from "vue";
+import { ShareNetwork } from "vue3-social-sharing";
+import socialNetworks from "@/data/social";
+
+defineProps({
+    puzzle: Object,
+});
+</script>

--- a/src/components/PuzzleTile.vue
+++ b/src/components/PuzzleTile.vue
@@ -55,52 +55,44 @@
 import { ref, computed } from "vue";
 import CryptoJS from "crypto-js";
 import { useChallenges } from "@/composables/useChallenges";
+
 const challenges = useChallenges();
 const props = defineProps({
     puzzle: Object,
 });
 
-const locked = ref(true);
-const solved = ref(false);
+const puzzle = computed(() => props.puzzle);
+const locked = computed(() => puzzle.value.unencryptedContent === undefined);
+
 const puzzleActive = ref(false);
 const errorMessage = ref("");
+const solved = ref(puzzle.value.metadata.solved === true);
 
-// If unencryptedContent is present, the puzzle is unlocked
-if (props.puzzle.unencryptedContent) {
-    locked.value = false;
-}
-
-// If the puzzle was already solved, set solved to true
-if (props.puzzle.metadata.solved === true) {
-    solved.value = true;
-}
-
-const unlockDate =
-    props.puzzle.metadata.unlockDate === undefined
-        ? false
-        : new Date(props.puzzle.metadata.unlockDate);
-
-// Define computed properties for the image URL, title, and teaser
 const imageUrl = computed(() =>
     locked.value === true
         ? "locked.jpg"
-        : props.puzzle.unencryptedContent.image_url || "locked.jpg",
+        : puzzle.value.unencryptedContent.image_url || "locked.jpg",
 );
 const title = computed(() =>
     locked.value === true
         ? "Locked Challenge"
-        : props.puzzle.unencryptedContent.title || "Unknown Challenge",
+        : puzzle.value.unencryptedContent.title || "Unknown Challenge",
 );
 const teaser = computed(() =>
     locked.value === true
         ? "Can you unlock it?"
-        : props.puzzle.unencryptedContent.description || "What is it?",
+        : puzzle.value.unencryptedContent.description || "What is it?",
 );
-const countdown = computed(() =>
+
+const unlockDate =
+    puzzle.value.metadata.unlockDate === undefined
+        ? false
+        : new Date(puzzle.value.metadata.unlockDate);
+
+const countdown =
     unlockDate === false
         ? "No automatic unlock."
-        : "Automatic unlock on " + unlockDate.toLocaleDateString() + ".",
-);
+        : "Automatic unlock on " + unlockDate.toLocaleDateString() + ".";
 
 function openPuzzle() {
     puzzleActive.value = true;
@@ -108,11 +100,10 @@ function openPuzzle() {
 }
 
 function handleSolve(userSolution) {
-    // Placeholder function to solve the puzzle
-    const checkString = decrypt(props.puzzle.answerCheck, userSolution);
+    const checkString = decrypt(puzzle.value.answerCheck, userSolution);
 
-    const currentChallenge = props.puzzle.metadata.challenge;
-    const currentPuzzle = props.puzzle.metadata.id;
+    const currentChallenge = puzzle.value.metadata.challenge;
+    const currentPuzzle = puzzle.value.metadata.id;
     const nextPuzzle = challenges.value[currentChallenge].puzzles[
         currentPuzzle + 1
     ]
@@ -124,15 +115,13 @@ function handleSolve(userSolution) {
         solved.value = true;
         errorMessage.value = "";
 
-        challenges.value[currentChallenge].puzzles[
-            currentPuzzle
-        ].metadata.solved = true;
-        challenges.value[currentChallenge].puzzles[
-            currentPuzzle
-        ].metadata.answer = userSolution;
-
-        // Close the puzzle
-        puzzleActive.value = false;
+        // Update the solved state and answer
+        challenges.value[currentChallenge].puzzles[currentPuzzle].metadata = {
+            ...challenges.value[currentChallenge].puzzles[currentPuzzle]
+                .metadata,
+            solved: true,
+            answer: userSolution,
+        };
 
         // Unencrypt the next puzzle
         if (
@@ -150,9 +139,19 @@ function handleSolve(userSolution) {
             const unencryptedContent = JSON.parse(
                 decrypt(encryptedContent, unencryptedSecret),
             );
-            challenges.value[currentChallenge].puzzles[
-                nextPuzzle
-            ].unencryptedContent = unencryptedContent;
+
+            if (unencryptedContent.image_url) {
+                unencryptedContent.image_url = new URL(
+                    `../assets/images/${unencryptedContent.image_url}`,
+                    import.meta.url,
+                ).href;
+            }
+
+            // Replace the next puzzle's unencryptedContent
+            challenges.value[currentChallenge].puzzles[nextPuzzle] = {
+                ...challenges.value[currentChallenge].puzzles[nextPuzzle],
+                unencryptedContent,
+            };
         }
     } else {
         errorMessage.value = "Solution is incorrect, try again.";

--- a/src/data/social.js
+++ b/src/data/social.js
@@ -1,0 +1,22 @@
+export default [
+    {
+        name: "facebook",
+        icon: "fa:fa-brands fa-facebook",
+        label: "Facebook",
+    },
+    {
+        name: "x",
+        icon: "fa:fa-brands fa-x-twitter",
+        label: "X/Twitter",
+    },
+    {
+        name: "bluesky",
+        icon: "fa:fa-brands fa-bluesky",
+        label: "Bluesky",
+    },
+    {
+        name: "linkedin",
+        icon: "fa:fa-brands fa-linkedin",
+        label: "Linkedin",
+    },
+];

--- a/src/data/social.js
+++ b/src/data/social.js
@@ -10,11 +10,6 @@ export default [
         label: "X/Twitter",
     },
     {
-        name: "bluesky",
-        icon: "fa:fa-brands fa-bluesky",
-        label: "Bluesky",
-    },
-    {
         name: "linkedin",
         icon: "fa:fa-brands fa-linkedin",
         label: "Linkedin",

--- a/src/data/social.js
+++ b/src/data/social.js
@@ -1,17 +1,22 @@
 export default [
     {
-        name: "facebook",
-        icon: "fa:fa-brands fa-facebook",
-        label: "Facebook",
-    },
-    {
-        name: "x",
-        icon: "fa:fa-brands fa-x-twitter",
-        label: "X/Twitter",
+        name: "bluesky",
+        icon: "fa:fa-brands fa-bluesky",
+        label: "Bluesky",
     },
     {
         name: "linkedin",
         icon: "fa:fa-brands fa-linkedin",
-        label: "Linkedin",
+        label: "LinkedIn",
+    },
+    {
+        name: "threads",
+        icon: "fa:fa-brands fa-threads",
+        label: "Threads",
+    },
+    {
+        name: "whatsapp",
+        icon: "fa:fa-brands fa-whatsapp",
+        label: "WhatsApp",
     },
 ];

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -6,7 +6,9 @@
 
 // Styles
 import "@mdi/font/css/materialdesignicons.css";
+import "@fortawesome/fontawesome-free/css/all.css";
 import "vuetify/styles";
+import { aliases, fa } from "vuetify/iconsets/fa";
 
 // Composables
 import { createVuetify } from "vuetify";
@@ -59,6 +61,12 @@ export default createVuetify({
         defaultTheme: "bellingcatDarkTheme",
         themes: {
             bellingcatDarkTheme,
+        },
+    },
+    icons: {
+        aliases,
+        sets: {
+            fa,
         },
     },
 });


### PR DESCRIPTION
Added social links upon challenge completion. Removed the `renderKey` increment workaround, as it caused the entire application to re-render whenever the `challenges` object changed. As a result, keeping the modal open after solving a challenge was not possible, since the app would reinitialize. I adjusted a few variables to react to changes dynamically, so the `renderKey` should no longer be necessary.